### PR TITLE
⚡ [performance] Add database indexes for Bookmark key

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, integer, uuid, primaryKey, date, boolean } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, integer, uuid, primaryKey, date, boolean, index, uniqueIndex } from "drizzle-orm/pg-core";
 import type { AdapterAccount } from "next-auth/adapters";
 
 // --- Users & Auth (Compatible with NextAuth.js) ---
@@ -117,6 +117,11 @@ export const bookmarks = pgTable("bookmark", {
 
     createdAt: timestamp("created_at").defaultNow(),
     updatedAt: timestamp("updated_at").defaultNow(),
+}, (table) => {
+    return {
+        keyIdx: index("bookmark_key_idx").on(table.key),
+        userKeyUniqueIdx: uniqueIndex("bookmark_user_key_unique_idx").on(table.userId, table.key),
+    };
 });
 
 // --- Intention Journal ---


### PR DESCRIPTION
💡 **What:** Added a B-tree index on the `key` column and a unique index on the compound `(userId, key)` for the `bookmarks` table.
🎯 **Why:**
- Improving query performance for bookmark lookups (reducing complexity from O(N) to O(log N)).
- Ensuring data integrity by preventing duplicate bookmarks for the same verse by the same user.
- Satisfying the requirement for `onConflictDoUpdate` operations used in the repository.
📊 **Measured Improvement:**
- Theoretical improvement from sequential scan (O(N)) to index scan (O(log N)).
- Direct measurement was not possible due to lack of a live database in the sandbox environment, but the change follows database optimization best practices.

---
*PR created automatically by Jules for task [9473421659368416529](https://jules.google.com/task/9473421659368416529) started by @hadianr*