### PR TITLE
🧹 refactor: move duplicated getHukumLabel to mission-utils.ts

### DIFF
--- a/src/app/misi/page.tsx
+++ b/src/app/misi/page.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePrayerTimes } from "@/hooks/usePrayerTimes";
 import MissionDetailDialog from "@/components/MissionDetailDialog";
-import { checkMissionValidation } from "@/lib/mission-utils";
+import { checkMissionValidation, getHukumLabel } from "@/lib/mission-utils";
 import { useLocale } from "@/context/LocaleContext";
 import { getStorageService } from "@/core/infrastructure/storage";
 import { STORAGE_KEYS } from "@/lib/constants/storage-keys";
@@ -31,16 +31,6 @@ export default function MisiPage() {
     const { t, locale } = useLocale();
     const [gender, setGender] = useState<Gender>(null);
 
-    const getHukumLabel = (hukum: string) => {
-        const labels: Record<string, keyof typeof t> = {
-            'wajib': 'hukumWajib',
-            'sunnah': 'hukumSunnah',
-            'mubah': 'hukumMubah',
-            'makruh': 'hukumMakruh',
-            'harram': 'hukumHaram'
-        };
-        return t[labels[hukum]] || hukum;
-    };
     const [missions, setMissions] = useState<Mission[]>([]);
     const [completed, setCompleted] = useState<CompletedMissions>({});
     const [today, setToday] = useState<string>("");
@@ -205,7 +195,7 @@ export default function MisiPage() {
                                     ? "bg-blue-500/20 text-blue-400 border border-blue-500/30"
                                     : "bg-emerald-500/20 text-emerald-400 border border-emerald-500/30"
                             )}>
-                                {getHukumLabel(mission.hukum)}
+                                {getHukumLabel(mission.hukum, t)}
                             </span>
                         </div>
                         {isGenderSpecific && (

--- a/src/components/MissionDetailDialog.tsx
+++ b/src/components/MissionDetailDialog.tsx
@@ -16,6 +16,7 @@ import { Mission, ValidationType } from "@/data/missions-data";
 import { MISSION_CONTENTS, MissionContent } from "@/data/mission-content";
 import { cn } from "@/lib/utils";
 import { useLocale } from "@/context/LocaleContext";
+import { getHukumLabel } from "@/lib/mission-utils";
 
 interface MissionDetailDialogProps {
     mission: Mission;
@@ -49,17 +50,6 @@ export default function MissionDetailDialog({
     const [readingIndex, setReadingIndex] = useState(0);
     const [isConfirmingReset, setIsConfirmingReset] = useState(false); // Add this
 
-    const getHukumLabel = (hukum: string) => {
-        const labels: Record<string, keyof typeof t> = {
-            'wajib': 'hukumWajib',
-            'sunnah': 'hukumSunnah',
-            'mubah': 'hukumMubah',
-            'makruh': 'hukumMakruh',
-            'harram': 'hukumHaram'
-        };
-        return t[labels[hukum]] || hukum;
-    };
-
     const handleNextReading = () => {
         if (content && content.readings && readingIndex < content.readings.length - 1) {
             setReadingIndex(prev => prev + 1);
@@ -91,7 +81,7 @@ export default function MissionDetailDialog({
                                         ? "bg-[rgb(var(--color-primary))]/20 text-[rgb(var(--color-primary-light))] border border-[rgb(var(--color-primary))]/30"
                                         : "bg-[rgb(var(--color-primary))]/20 text-[rgb(var(--color-primary-light))] border border-[rgb(var(--color-primary))]/30"
                                 )}>
-                                    {getHukumLabel(mission.hukum)}
+                                        {getHukumLabel(mission.hukum, t)}
                                 </span>
                             </div>
                             <p className="text-xs text-white/50 mt-1">{mission.description}</p>

--- a/src/components/MissionListModal.tsx
+++ b/src/components/MissionListModal.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { Check, CheckCircle2, Sparkles, AlertCircle } from "lucide-react";
 import MissionDetailDialog from "./MissionDetailDialog";
 import { useLocale } from "@/context/LocaleContext";
+import { getHukumLabel } from "@/lib/mission-utils";
 
 interface MissionListModalProps {
     missions: Mission[];
@@ -36,17 +37,6 @@ export default function MissionListModal({
 }: MissionListModalProps) {
     const [activeTab, setActiveTab] = useState(initialTab || "all");
     const { t } = useLocale();
-
-    const getHukumLabel = (hukum: string) => {
-        const labels: Record<string, keyof typeof t> = {
-            'wajib': 'hukumWajib',
-            'sunnah': 'hukumSunnah',
-            'mubah': 'hukumMubah',
-            'makruh': 'hukumMakruh',
-            'harram': 'hukumHaram'
-        };
-        return t[labels[hukum]] || hukum;
-    };
 
     // Sync active tab if initialTab changes (re-opening logic)
     // Note: In a real app we might want a useEffect on open.
@@ -154,7 +144,7 @@ export default function MissionListModal({
                                                 ? "bg-blue-500/10 text-blue-400 border-blue-500/20"
                                                 : "bg-emerald-500/10 text-emerald-400 border-emerald-500/20"
                                         )}>
-                                            {getHukumLabel(mission.hukum)}
+                                            {getHukumLabel(mission.hukum, t)}
                                         </span>
                                     </div>
                                 </div>

--- a/src/components/MissionsWidget.tsx
+++ b/src/components/MissionsWidget.tsx
@@ -11,7 +11,7 @@ import { usePrayerTimes } from "@/hooks/usePrayerTimes";
 import { useMissions } from "@/hooks/useMissions";
 import MissionDetailDialog from "./MissionDetailDialog";
 import MissionListModal from "./MissionListModal";
-import { checkMissionValidation, filterMissionsByArchetype } from "@/lib/mission-utils";
+import { checkMissionValidation, filterMissionsByArchetype, getHukumLabel } from "@/lib/mission-utils";
 import MissionSkeleton from "@/components/skeleton/MissionSkeleton";
 import { useLocale } from "@/context/LocaleContext";
 import { getStorageService } from "@/core/infrastructure/storage";
@@ -42,17 +42,6 @@ export default function MissionsWidget() {
 
     // Intention Prompt State
     const [showIntentionPrompt, setShowIntentionPrompt] = useState(false);
-
-    const getHukumLabel = (hukum: string) => {
-        const labels: Record<string, keyof typeof t> = {
-            wajib: "hukumWajib",
-            sunnah: "hukumSunnah",
-            mubah: "hukumMubah",
-            makruh: "hukumMakruh",
-            harram: "hukumHaram"
-        };
-        return t[labels[hukum]] || hukum;
-    };
 
     const { data: prayerData } = usePrayerTimes();
 
@@ -534,7 +523,7 @@ export default function MissionsWidget() {
                                                 ? "bg-blue-500/20 text-blue-400 border border-blue-500/30"
                                                 : "bg-[rgb(var(--color-primary))]/20 text-[rgb(var(--color-primary-light))] border-[rgb(var(--color-primary))]/20"
                                         )}>
-                                            {getHukumLabel(mission.hukum)}
+                                            {getHukumLabel(mission.hukum, t)}
                                         </span>
                                         <p className="text-[10px] text-white/90 truncate">
                                             +{mission.xpReward} XP

--- a/src/lib/mission-utils.ts
+++ b/src/lib/mission-utils.ts
@@ -1,4 +1,5 @@
 import { Mission } from "@/data/missions-data";
+import { SETTINGS_TRANSLATIONS } from "@/data/settings-translations";
 
 export interface ValidationResult {
     locked: boolean;
@@ -158,4 +159,19 @@ export function filterMissionsByArchetype(missions: Mission[], archetype: string
                 return true;
         }
     });
+}
+
+/**
+ * Gets the localized label for a mission's hukum (wajib, sunnah, etc.)
+ */
+export function getHukumLabel(hukum: string, t: typeof SETTINGS_TRANSLATIONS.id) {
+    const labels: Record<string, keyof typeof SETTINGS_TRANSLATIONS.id> = {
+        'wajib': 'hukumWajib',
+        'sunnah': 'hukumSunnah',
+        'mubah': 'hukumMubah',
+        'makruh': 'hukumMakruh',
+        'harram': 'hukumHaram'
+    };
+    const key = labels[hukum];
+    return t[key as keyof typeof SETTINGS_TRANSLATIONS.id] || hukum;
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a duplicated helper function `getHukumLabel` found in multiple components.
💡 **Why:** Moving this to `src/lib/mission-utils.ts` improves maintainability by centralizing the logic. If hukum labels or translation mappings change, they only need to be updated in one place.
✅ **Verification:** Changes were verified through manual code review to ensure the logic was correctly ported and all call sites were updated. Functional behavior remains unchanged.
✨ **Result:** Improved codebase maintainability and reduced code duplication.

---
*PR created automatically by Jules for task [11554110417125882920](https://jules.google.com/task/11554110417125882920) started by @hadianr*