### PR TITLE
🔒 [security fix] Remove sensitive PII logging to local file

### DIFF
--- a/src/app/api/payment/create/route.ts
+++ b/src/app/api/payment/create/route.ts
@@ -4,8 +4,6 @@ import { authOptions } from "@/lib/auth";
 import { db } from "@/db";
 import { transactions, users } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import fs from "fs";
-import path from "path";
 
 export async function POST(req: NextRequest) {
     try {
@@ -54,14 +52,6 @@ export async function POST(req: NextRequest) {
         const mayarData = await mayarRes.json();
 
         if (!mayarRes.ok) {
-
-            // Log to local file for agent to read
-            try {
-                const logMsg = `[${new Date().toISOString()}] BODY: ${JSON.stringify(body)} | ERROR: ${JSON.stringify(mayarData)}\n`;
-                fs.appendFileSync(path.join(process.cwd(), "MAYAR_ERROR.log"), logMsg);
-            } catch (err) {
-            }
-
             // Mayar often uses 'messages' instead of 'message' or 'error'
             const errorMessage =
                 mayarData?.messages ||
@@ -69,9 +59,10 @@ export async function POST(req: NextRequest) {
                 mayarData?.error ||
                 (typeof mayarData === 'string' ? mayarData : "Failed to create payment link");
 
+            console.error(`[${new Date().toISOString()}] Mayar Payment Creation Failed:`, errorMessage);
+
             return NextResponse.json({
-                error: typeof errorMessage === 'object' ? JSON.stringify(errorMessage) : errorMessage,
-                debug: mayarData
+                error: typeof errorMessage === 'object' ? JSON.stringify(errorMessage) : errorMessage
             }, { status: 500 });
         }
 


### PR DESCRIPTION
This PR fixes a security vulnerability where sensitive Personally Identifiable Information (PII) was being logged to a local file in the root directory.

🎯 **What:** The vulnerability fixed is the use of `fs.appendFileSync` to log the `body` and `mayarData` objects to `MAYAR_ERROR.log`. These objects contained sensitive user data such as name, email, and mobile number.

⚠️ **Risk:** 
- **Data Exposure:** Sensitive user information was stored in plain text in the application's root directory. If the server were compromised, this data would be easily accessible.
- **Serverless Incompatibility:** Writing to the local filesystem is insecure and often fails in serverless environments like Vercel, where the filesystem is typically read-only or ephemeral.
- **Information Disclosure:** The API was returning raw upstream error data (`mayarData`) to the client, which could leak internal system details.

🛡️ **Solution:** 
- Removed the `fs` and `path` imports.
- Deleted the code block that wrote to `MAYAR_ERROR.log`.
- Replaced the insecure logging with a safe `console.error` that only logs the error message.
- Removed the `debug` field from the error response to the client to ensure no PII or internal details are leaked.

---
*PR created automatically by Jules for task [13252358596623025373](https://jules.google.com/task/13252358596623025373) started by @hadianr*