### PR TITLE
Sweep: Refactor server-side analytics with structured provider

### DIFF
--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { trackMetric, WebVitalMetric } from "@/lib/server-analytics";
 
 /**
  * Analytics API endpoint for Web Vitals metrics
@@ -6,15 +7,14 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function POST(request: NextRequest) {
     try {
-        const metric = await request.json();
+        const metric = await request.json() as WebVitalMetric;
 
-        // Log metrics in production for monitoring
-
-        // TODO: In future, send to analytics service (Google Analytics, Vercel Analytics, etc.)
-        // Example: await sendToGoogleAnalytics(metric);
+        // Log metrics using the configured analytics provider
+        await trackMetric(metric);
 
         return NextResponse.json({ success: true }, { status: 200 });
     } catch (error) {
+        console.error("[Analytics API Error]", error);
         return NextResponse.json(
             { error: "Failed to process metric" },
             { status: 500 }

--- a/src/lib/server-analytics.test.ts
+++ b/src/lib/server-analytics.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { trackMetric, WebVitalMetric } from './server-analytics';
+
+describe('server-analytics', () => {
+    it('should log metric to console', async () => {
+        const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+        const metric: WebVitalMetric = {
+            id: 'test-id',
+            name: 'FCP',
+            value: 100,
+            startTime: 0,
+            label: 'web-vital'
+        };
+
+        await trackMetric(metric);
+
+        expect(consoleSpy).toHaveBeenCalledWith('[Analytics] Web Vital: FCP', metric);
+
+        consoleSpy.mockRestore();
+    });
+});

--- a/src/lib/server-analytics.ts
+++ b/src/lib/server-analytics.ts
@@ -1,0 +1,31 @@
+export interface WebVitalMetric {
+    id: string;
+    name: string;
+    startTime: number;
+    value: number;
+    label: 'web-vital' | 'custom';
+}
+
+export interface AnalyticsProvider {
+    trackMetric(metric: WebVitalMetric): Promise<void>;
+}
+
+class ConsoleAnalyticsProvider implements AnalyticsProvider {
+    async trackMetric(metric: WebVitalMetric): Promise<void> {
+        console.info(`[Analytics] Web Vital: ${metric.name}`, metric);
+    }
+}
+
+// Factory to get the configured provider
+export function getAnalyticsProvider(): AnalyticsProvider {
+    // In future, return different provider based on config
+    return new ConsoleAnalyticsProvider();
+}
+
+/**
+ * Tracks a web vital metric using the configured analytics provider.
+ */
+export async function trackMetric(metric: WebVitalMetric): Promise<void> {
+    const provider = getAnalyticsProvider();
+    await provider.trackMetric(metric);
+}


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored `src/app/api/analytics/route.ts` to use a dedicated `server-analytics.ts` library for handling Web Vitals metrics.

💡 **Why:** How this improves maintainability
The original route contained logic (logging and TODOs) mixed with route handling. By moving the analytics logic to a provider-based service (`AnalyticsProvider`), we separate concerns. This makes it easier to swap implementations (e.g., from console logging to GA4 or Sentry) without modifying the route handler itself. It also introduces type safety for metrics via `WebVitalMetric`.

✅ **Verification:** How you confirmed the change is safe
- Ran `npm run test:run src/lib/server-analytics.test.ts` which passed.
- Verified file contents using `read_file`.
- Reverted unintentional `package-lock.json` changes to avoid dependency conflicts.

✨ **Result:** The improvement achieved
A cleaner, type-safe, and extensible analytics integration point ready for future enhancement.

---
*PR created automatically by Jules for task [4314766234259505005](https://jules.google.com/task/4314766234259505005) started by @hadianr*