### PR TITLE
fix: prevent internal error details exposure in production API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nawaetu",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nawaetu",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "dependencies": {
         "@auth/drizzle-adapter": "^1.11.1",
         "@ducanh2912/next-pwa": "^10.2.9",

--- a/src/app/api/intentions/daily/route.test.ts
+++ b/src/app/api/intentions/daily/route.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST } from './route';
+import { NextRequest } from 'next/server';
+
+// Mock the dependencies
+// The db mock needs to return objects that allow chaining as used in the route
+vi.mock('@/db', () => ({
+  db: {
+    select: vi.fn(),
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+    insert: vi.fn(),
+    values: vi.fn(),
+    returning: vi.fn(),
+    update: vi.fn(),
+    set: vi.fn(),
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+// We rely on the global mock for next/server from setup.ts
+// But if we need to inspect the response, we need to know its shape.
+// Based on src/__tests__/setup.ts, NextResponse.json returns { body, status }
+
+describe('POST /api/intentions/daily', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it('should expose error details in development environment', async () => {
+    // Setup
+    process.env.NODE_ENV = 'development';
+    const { db } = await import('@/db');
+
+    // Mock db failure
+    (db.select as any).mockImplementation(() => {
+        throw new Error('Database connection failed: confidential info');
+    });
+
+    // using the mocked NextRequest from setup.ts
+    const req = new NextRequest('http://localhost:3000/api/intentions/daily', {
+      method: 'POST',
+      body: JSON.stringify({
+        user_token: 'test-token',
+        niat_text: 'Test intention',
+      }),
+    });
+
+    // Execute
+    const response = await POST(req);
+    // The mocked NextResponse.json returns { body, status }
+    const data = (response as any).body;
+    const status = (response as any).status;
+
+    // Verify
+    expect(status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe('Internal server error');
+    // In dev, details should be present
+    expect(data.details).toBe('Database connection failed: confidential info');
+  });
+
+  it('should NOT expose error details in production environment', async () => {
+    // Setup
+    process.env.NODE_ENV = 'production';
+    const { db } = await import('@/db');
+
+    // Mock db failure
+    (db.select as any).mockImplementation(() => {
+        throw new Error('Database connection failed: confidential info');
+    });
+
+    const req = new NextRequest('http://localhost:3000/api/intentions/daily', {
+      method: 'POST',
+      body: JSON.stringify({
+        user_token: 'test-token',
+        niat_text: 'Test intention',
+      }),
+    });
+
+    // Execute
+    const response = await POST(req);
+    // The mocked NextResponse.json returns { body, status }
+    const data = (response as any).body;
+    const status = (response as any).status;
+
+    // Verify
+    expect(status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe('Internal server error');
+    // In prod, details should be undefined.
+    // This expectation will fail currently, confirming the vulnerability.
+    expect(data.details).toBeUndefined();
+  });
+});

--- a/src/app/api/intentions/daily/route.ts
+++ b/src/app/api/intentions/daily/route.ts
@@ -212,12 +212,13 @@ export async function POST(req: NextRequest) {
         });
     } catch (error: any) {
         // Return detailed error message for debugging
+        const isDev = process.env.NODE_ENV === 'development';
         return NextResponse.json(
             {
                 success: false,
                 error: "Internal server error",
-                details: error.message,
-                stack: process.env.NODE_ENV === 'development' ? error.stack : undefined
+                details: isDev ? error.message : undefined,
+                stack: isDev ? error.stack : undefined
             },
             { status: 500 }
         );


### PR DESCRIPTION
This PR addresses a security vulnerability where internal error details (including database errors) were exposed in the API response in production.
- Modified `src/app/api/intentions/daily/route.ts` to conditionally include `details` and `stack` only when `NODE_ENV === 'development'`.
- Added `src/app/api/intentions/daily/route.test.ts` to verify the fix and prevent regression.

---
*PR created automatically by Jules for task [5322323926850094119](https://jules.google.com/task/5322323926850094119) started by @hadianr*