### PR TITLE
🔒 Fix: Prevent exposure of internal error details in API response

### DIFF
--- a/src/app/api/intentions/daily/route.test.ts
+++ b/src/app/api/intentions/daily/route.test.ts
@@ -36,7 +36,7 @@ describe('POST /api/intentions/daily', () => {
     process.env.NODE_ENV = originalEnv;
   });
 
-  it('should expose error details in development environment', async () => {
+  it('should NOT expose error details in development environment', async () => {
     // Setup
     process.env.NODE_ENV = 'development';
     const { db } = await import('@/db');
@@ -65,8 +65,8 @@ describe('POST /api/intentions/daily', () => {
     expect(status).toBe(500);
     expect(data.success).toBe(false);
     expect(data.error).toBe('Internal server error');
-    // In dev, details should be present
-    expect(data.details).toBe('Database connection failed: confidential info');
+    // details should NOT be present even in dev
+    expect(data.details).toBeUndefined();
   });
 
   it('should NOT expose error details in production environment', async () => {
@@ -98,7 +98,6 @@ describe('POST /api/intentions/daily', () => {
     expect(data.success).toBe(false);
     expect(data.error).toBe('Internal server error');
     // In prod, details should be undefined.
-    // This expectation will fail currently, confirming the vulnerability.
     expect(data.details).toBeUndefined();
   });
 });

--- a/src/app/api/intentions/daily/route.ts
+++ b/src/app/api/intentions/daily/route.ts
@@ -211,14 +211,14 @@ export async function POST(req: NextRequest) {
             },
         });
     } catch (error: any) {
-        // Return detailed error message for debugging
-        const isDev = process.env.NODE_ENV === 'development';
+        // Log error for debugging
+        console.error("Error in POST /api/intentions/daily:", error);
+
+        // Return generic error message to prevent information leakage
         return NextResponse.json(
             {
                 success: false,
                 error: "Internal server error",
-                details: isDev ? error.message : undefined,
-                stack: isDev ? error.stack : undefined
             },
             { status: 500 }
         );


### PR DESCRIPTION
This PR fixes a security vulnerability where internal error details (message and stack trace) could be exposed in the API response. 

Changes:
- Modified `src/app/api/intentions/daily/route.ts` to remove the conditional inclusion of error details. Now, generic error messages are returned in all environments.
- Added `console.error` to log the full error details on the server side, ensuring debuggability is maintained via logs.
- Updated `src/app/api/intentions/daily/route.test.ts` to assert that `details` are strictly hidden in all environments.

---
*PR created automatically by Jules for task [12856068633157750071](https://jules.google.com/task/12856068633157750071) started by @hadianr*