### PR TITLE
Refactor useRamadhanCalendar types

### DIFF
--- a/src/hooks/useRamadhanCalendar.test.tsx
+++ b/src/hooks/useRamadhanCalendar.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useRamadhanCalendar } from "./useRamadhanCalendar";
+import { fetchWithTimeout } from "@/lib/utils/fetch";
+import { resetStorageService } from "@/core/infrastructure/storage";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// Mock fetchWithTimeout
+vi.mock("@/lib/utils/fetch", () => ({
+    fetchWithTimeout: vi.fn(),
+}));
+
+describe("useRamadhanCalendar", () => {
+    beforeEach(() => {
+        resetStorageService();
+        localStorage.clear();
+        vi.clearAllMocks();
+    });
+
+    it("fetches and processes calendar data correctly", async () => {
+        const mockResponse = {
+            data: [
+                {
+                    timings: {
+                        Fajr: "04:30 (WIB)",
+                        Sunrise: "05:45 (WIB)",
+                        Dhuhr: "12:00 (WIB)",
+                        Asr: "15:15 (WIB)",
+                        Sunset: "18:00 (WIB)",
+                        Maghrib: "18:05 (WIB)",
+                        Isha: "19:15 (WIB)",
+                        Imsak: "04:20 (WIB)",
+                        Midnight: "00:00 (WIB)",
+                    },
+                    date: {
+                        readable: "20 Feb 2026",
+                        timestamp: "1771545600",
+                        gregorian: {
+                            date: "20-02-2026",
+                            format: "DD-MM-YYYY",
+                            day: "20",
+                            weekday: { en: "Friday" },
+                            month: { number: 2, en: "February" },
+                            year: "2026",
+                            designation: { abbreviated: "AD", expanded: "Anno Domini" },
+                        },
+                        hijri: {
+                            date: "02-09-1447",
+                            format: "DD-MM-YYYY",
+                            day: "02",
+                            weekday: { en: "Al-Jumu'ah", ar: "الجمعة" },
+                            month: { number: 9, en: "Ramadan", ar: "رمضان" },
+                            year: "1447",
+                            designation: { abbreviated: "AH", expanded: "Anno Hegirae" },
+                            holidays: [],
+                        },
+                    },
+                },
+            ],
+        };
+
+        (fetchWithTimeout as any).mockResolvedValue({
+            json: async () => mockResponse,
+        });
+
+        const { result } = renderHook(() => useRamadhanCalendar());
+
+        // Trigger fetch
+        await act(async () => {
+             await result.current.fetchCalendar();
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+            // Expect at least 1 day because fetch is called twice for 2 months, potentially duplicating if mock is static
+            expect(result.current.calendarData.length).toBeGreaterThan(0);
+        });
+
+        const day = result.current.calendarData[0];
+        // 2 Ramadan - 1 adjustment = 1 Ramadan
+        expect(day.hijriDate).toContain("1 Ramadan 1447H");
+        expect(day.timings.Subuh).toBe("04:30");
+        expect(day.timings.Maghrib).toBe("18:05");
+    });
+
+    it("handles errors gracefully", async () => {
+        (fetchWithTimeout as any).mockRejectedValue(new Error("Network Error"));
+
+        const { result } = renderHook(() => useRamadhanCalendar());
+
+        await act(async () => {
+             await result.current.fetchCalendar();
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+            expect(result.current.error).toBe("Network Error");
+            expect(result.current.calendarData).toEqual([]);
+        });
+    });
+});

--- a/src/hooks/useRamadhanCalendar.ts
+++ b/src/hooks/useRamadhanCalendar.ts
@@ -3,6 +3,7 @@ import { getStorageService } from "@/core/infrastructure/storage";
 import { STORAGE_KEYS } from "@/lib/constants/storage-keys";
 import { API_CONFIG } from "@/config/apis";
 import { fetchWithTimeout } from "@/lib/utils/fetch";
+import { AladhanCalendarResponse, AladhanDayData } from "@/types/aladhan";
 
 const storage = getStorageService();
 
@@ -46,7 +47,7 @@ export function useRamadhanCalendar() {
 
         try {
             // Get Location
-            const cachedLocation = storage.getOptional<any>(STORAGE_KEYS.USER_LOCATION as any);
+            const cachedLocation = storage.getOptional<{ lat: number; lng: number }>(STORAGE_KEYS.USER_LOCATION);
             if (!cachedLocation || !cachedLocation.lat || !cachedLocation.lng) {
                 // If no location, we can't fetch reliable calendar.
                 // Fallback to Jakarta for now or throw error.
@@ -57,10 +58,10 @@ export function useRamadhanCalendar() {
             const lng = cachedLocation?.lng || 106.827153;
 
             // Get Settings
-            const savedMethod = storage.getOptional<string>(STORAGE_KEYS.SETTINGS_CALCULATION_METHOD as any);
+            const savedMethod = storage.getOptional<string>(STORAGE_KEYS.SETTINGS_CALCULATION_METHOD);
             const method = (typeof savedMethod === 'string' ? savedMethod : savedMethod) || "20";
 
-            const savedAdjustment = storage.getOptional<string>(STORAGE_KEYS.SETTINGS_HIJRI_ADJUSTMENT as any);
+            const savedAdjustment = storage.getOptional<string>(STORAGE_KEYS.SETTINGS_HIJRI_ADJUSTMENT);
             const activeAdj = parseInt((typeof savedAdjustment === 'string' ? savedAdjustment : savedAdjustment) || "-1", 10);
 
             // Fetch Feb & March 2026 (Ramadhan 1447 spans Feb 18 - Mar 19)
@@ -75,12 +76,12 @@ export function useRamadhanCalendar() {
                     `${API_CONFIG.ALADHAN.BASE_URL}/calendar/${year}/${m}?latitude=${lat}&longitude=${lng}&method=${method}&adjustment=${activeAdj}`,
                     {},
                     { timeoutMs: 10000 }
-                ).then(res => res.json())
+                ).then(res => res.json() as Promise<AladhanCalendarResponse>)
             );
 
             const updates = await Promise.all(requests);
 
-            const allDays: any[] = [];
+            const allDays: AladhanDayData[] = [];
             updates.forEach(update => {
                 if (update.data && Array.isArray(update.data)) {
                     allDays.push(...update.data);
@@ -146,7 +147,7 @@ export function useRamadhanCalendar() {
         } finally {
             setLoading(false);
         }
-    }, [storage]); // Added dependency
+    }, []);
 
     return { calendarData, loading, error, fetchCalendar };
 }

--- a/src/types/aladhan.ts
+++ b/src/types/aladhan.ts
@@ -1,0 +1,103 @@
+export interface AladhanTimings {
+    Fajr: string;
+    Sunrise: string;
+    Dhuhr: string;
+    Asr: string;
+    Sunset: string;
+    Maghrib: string;
+    Isha: string;
+    Imsak: string;
+    Midnight: string;
+    Firstthird?: string;
+    Lastthird?: string;
+}
+
+export interface AladhanGregorianDate {
+    date: string;
+    format: string;
+    day: string;
+    weekday: {
+        en: string;
+    };
+    month: {
+        number: number;
+        en: string;
+    };
+    year: string;
+    designation: {
+        abbreviated: string;
+        expanded: string;
+    };
+}
+
+export interface AladhanHijriDate {
+    date: string;
+    format: string;
+    day: string;
+    weekday: {
+        en: string;
+        ar: string;
+    };
+    month: {
+        number: number;
+        en: string;
+        ar: string;
+    };
+    year: string;
+    designation: {
+        abbreviated: string;
+        expanded: string;
+    };
+    holidays: string[];
+}
+
+export interface AladhanDate {
+    readable: string;
+    timestamp: string;
+    gregorian: AladhanGregorianDate;
+    hijri: AladhanHijriDate;
+}
+
+export interface AladhanMeta {
+    latitude: number;
+    longitude: number;
+    timezone: string;
+    method: {
+        id: number;
+        name: string;
+        params: {
+            Fajr: number;
+            Isha: number;
+        };
+        location: {
+            latitude: number;
+            longitude: number;
+        };
+    };
+    latitudeAdjustmentMethod: string;
+    midnightMode: string;
+    school: string;
+    offset: {
+        Imsak: number;
+        Fajr: number;
+        Sunrise: number;
+        Dhuhr: number;
+        Asr: number;
+        Maghrib: number;
+        Sunset: number;
+        Isha: number;
+        Midnight: number;
+    };
+}
+
+export interface AladhanDayData {
+    timings: AladhanTimings;
+    date: AladhanDate;
+    meta?: AladhanMeta;
+}
+
+export interface AladhanCalendarResponse {
+    code: number;
+    status: string;
+    data: AladhanDayData[];
+}


### PR DESCRIPTION
This PR addresses a code health issue in `src/hooks/useRamadhanCalendar.ts` by replacing `any` types with proper interfaces for the Aladhan API response. It also adds a unit test to verify the hook's functionality and improves type safety for storage operations.

---
*PR created automatically by Jules for task [3327526488685837359](https://jules.google.com/task/3327526488685837359) started by @hadianr*