### PR TITLE
⚡ Optimize notifications subscribe upsert

### DIFF
--- a/src/app/api/notifications/subscribe/route.test.ts
+++ b/src/app/api/notifications/subscribe/route.test.ts
@@ -1,0 +1,114 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { POST } from './route';
+import { db } from '@/db';
+import { pushSubscriptions } from '@/db/schema';
+import { NextRequest } from 'next/server';
+
+// Mock dependencies
+vi.mock('@/db', () => ({
+    db: {
+        select: vi.fn(),
+        update: vi.fn(),
+        insert: vi.fn(),
+    }
+}));
+
+vi.mock('@/db/schema', () => ({
+    pushSubscriptions: {
+        token: { name: 'token' },
+        updatedAt: { name: 'updated_at' },
+        active: { name: 'active' },
+        deviceType: { name: 'device_type' },
+        timezone: { name: 'timezone' },
+        userLocation: { name: 'user_location' },
+        latitude: { name: 'latitude' },
+        longitude: { name: 'longitude' },
+        city: { name: 'city' },
+        prayerPreferences: { name: 'prayer_preferences' },
+        userId: { name: 'userId' },
+        lastUsedAt: { name: 'last_used_at' },
+    }
+}));
+
+vi.mock('drizzle-orm', () => ({
+    eq: vi.fn(),
+}));
+
+describe('POST /api/notifications/subscribe', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should upsert subscription using single query (Optimized)', async () => {
+        // Mock insert().values().onConflictDoUpdate() chain
+        const mockOnConflictDoUpdate = vi.fn().mockResolvedValue({});
+        const mockValues = vi.fn().mockReturnValue({
+            onConflictDoUpdate: mockOnConflictDoUpdate
+        });
+        const mockInsert = vi.fn().mockReturnValue({
+             values: mockValues
+        });
+        (db.insert as any).mockImplementation(mockInsert);
+
+        const req = new NextRequest('http://localhost', {
+            method: 'POST',
+            body: JSON.stringify({ token: 'token123', prayerPreferences: { fajr: true } })
+        });
+
+        await POST(req);
+
+        // Verify optimized behavior: Only Insert called (with upsert logic)
+        expect(db.insert).toHaveBeenCalledTimes(1);
+        expect(db.select).not.toHaveBeenCalled(); // No read before write
+        expect(db.update).not.toHaveBeenCalled(); // No separate update
+
+        // Verify arguments
+        // 1. insert called with table
+        expect(db.insert).toHaveBeenCalledWith(pushSubscriptions);
+
+        // 2. values called with correct data
+        expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({
+            token: 'token123',
+            prayerPreferences: { fajr: true },
+            active: 1
+        }));
+
+        // 3. onConflictDoUpdate called with correct config
+        expect(mockOnConflictDoUpdate).toHaveBeenCalledWith(expect.objectContaining({
+            target: pushSubscriptions.token,
+            set: expect.objectContaining({
+                prayerPreferences: { fajr: true },
+                active: 1
+            })
+        }));
+    });
+
+    it('should handle missing prayerPreferences correctly in upsert', async () => {
+        // Mock insert().values().onConflictDoUpdate() chain
+        const mockOnConflictDoUpdate = vi.fn().mockResolvedValue({});
+        const mockValues = vi.fn().mockReturnValue({
+            onConflictDoUpdate: mockOnConflictDoUpdate
+        });
+        const mockInsert = vi.fn().mockReturnValue({
+             values: mockValues
+        });
+        (db.insert as any).mockImplementation(mockInsert);
+
+        const req = new NextRequest('http://localhost', {
+            method: 'POST',
+            body: JSON.stringify({ token: 'token123' }) // missing prayerPreferences
+        });
+
+        await POST(req);
+
+        // Verify values received null for prayerPreferences (for insert)
+        expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({
+            token: 'token123',
+            prayerPreferences: null
+        }));
+
+        // Verify set received undefined for prayerPreferences (for update - so it's ignored)
+        const setArg = mockOnConflictDoUpdate.mock.calls[0][0].set;
+        expect(setArg.prayerPreferences).toBeUndefined();
+    });
+});


### PR DESCRIPTION
💡 **What:** Replaced the "check-then-act" (select then update/insert) pattern in `src/app/api/notifications/subscribe/route.ts` with a single atomic `INSERT ... ON CONFLICT DO UPDATE` query using Drizzle ORM.
🎯 **Why:** To reduce database round trips from 2 to 1 and prevent potential race conditions, improving the efficiency of the subscription endpoint.
📊 **Measured Improvement:** Verified via unit tests (`src/app/api/notifications/subscribe/route.test.ts`) that the operation now performs exactly 1 database call (insert with upsert logic) instead of the previous 2 calls. Handled edge cases like missing `prayerPreferences` correctly to preserve existing behavior.

---
*PR created automatically by Jules for task [1860020715398460730](https://jules.google.com/task/1860020715398460730) started by @hadianr*