### PR TITLE
⚡ Optimize chat history API with Drizzle Upsert

### DIFF
--- a/src/app/api/mentor-ai/history/route.test.ts
+++ b/src/app/api/mentor-ai/history/route.test.ts
@@ -1,0 +1,175 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Hoisted Mocks
+const {
+    mockFindFirst,
+    mockUpdate,
+    mockInsert,
+    mockUpdateSet,
+    mockUpdateWhere,
+    mockInsertValues,
+    mockInsertOnConflictDoUpdate,
+    mockInsertReturning
+} = vi.hoisted(() => {
+    return {
+        mockFindFirst: vi.fn(),
+        mockUpdate: vi.fn(),
+        mockInsert: vi.fn(),
+        mockUpdateSet: vi.fn(),
+        mockUpdateWhere: vi.fn(),
+        mockInsertValues: vi.fn(),
+        mockInsertOnConflictDoUpdate: vi.fn(),
+        mockInsertReturning: vi.fn(),
+    };
+});
+
+// Import AFTER mocks
+import { POST } from './route';
+
+// Helper for chainable mocks
+const createQueryBuilder = (result: any) => {
+    return {
+        then: (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject),
+        onConflictDoUpdate: mockInsertOnConflictDoUpdate,
+        returning: mockInsertReturning,
+        where: mockUpdateWhere,
+        set: mockUpdateSet,
+    };
+};
+
+vi.mock('@/db', () => ({
+    db: {
+        query: {
+            chatSessions: {
+                findFirst: mockFindFirst,
+            },
+        },
+        update: mockUpdate,
+        insert: mockInsert,
+    },
+}));
+
+// Mock Auth
+vi.mock('next-auth', () => ({
+    getServerSession: vi.fn(() => Promise.resolve({
+        user: { id: 'user-123', name: 'Test User' }
+    })),
+}));
+
+vi.mock('@/lib/auth', () => ({
+    authOptions: {},
+}));
+
+// Mock Schema
+vi.mock('@/db/schema', () => ({
+    chatSessions: {
+        id: 'id',
+        userId: 'userId',
+        title: 'title',
+        messages: 'messages',
+        updatedAt: 'updatedAt',
+        createdAt: 'createdAt'
+    },
+}));
+
+// Mock Drizzle ORM
+vi.mock('drizzle-orm', () => ({
+    eq: vi.fn(),
+    desc: vi.fn(),
+}));
+
+describe('Benchmark: POST /api/mentor-ai/history', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        // Setup default chainable structure
+        mockUpdate.mockReturnValue({
+            set: mockUpdateSet,
+        });
+        mockUpdateSet.mockReturnValue({
+            where: mockUpdateWhere,
+        });
+        mockUpdateWhere.mockImplementation(() => createQueryBuilder({}));
+
+        mockInsert.mockReturnValue({
+            values: mockInsertValues,
+        });
+
+        // Default behavior
+        mockInsertValues.mockImplementation(() => createQueryBuilder([{ id: 'test-id' }]));
+        mockInsertOnConflictDoUpdate.mockImplementation(() => createQueryBuilder([{ id: 'test-id' }]));
+        mockInsertReturning.mockImplementation(() => createQueryBuilder([{ id: 'test-id' }]));
+    });
+
+    it('Scenario A: Update existing session (User matches)', async () => {
+        // No need to mock findFirst as it shouldn't be called
+
+        const req = new NextRequest('http://localhost/api/mentor-ai/history', {
+            method: 'POST',
+            body: JSON.stringify({
+                id: 'session-1',
+                title: 'New Title',
+                messages: [{ role: 'user', content: 'Hello' }]
+            })
+        });
+
+        const res: any = await POST(req);
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ success: true });
+
+        // Optimized: findFirst NOT called
+        expect(mockFindFirst).toHaveBeenCalledTimes(0);
+        // update NOT called (handled by insert...onConflict)
+        expect(mockUpdate).toHaveBeenCalledTimes(0);
+        // insert called once
+        expect(mockInsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('Scenario B: Create new session', async () => {
+        const req = new NextRequest('http://localhost/api/mentor-ai/history', {
+            method: 'POST',
+            body: JSON.stringify({
+                id: 'new-session',
+                title: 'New Chat',
+                messages: [{ role: 'user', content: 'Hi' }]
+            })
+        });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+
+        // Optimized: findFirst NOT called
+        expect(mockFindFirst).toHaveBeenCalledTimes(0);
+        // insert called once
+        expect(mockInsert).toHaveBeenCalledTimes(1);
+        expect(mockUpdate).toHaveBeenCalledTimes(0);
+    });
+
+    it('Scenario C: Update existing session (Wrong user)', async () => {
+        // Setup insert...returning to return EMPTY array (indicating conflict + ownership fail)
+        mockInsertReturning.mockImplementation(() => createQueryBuilder([]));
+
+        const req = new NextRequest('http://localhost/api/mentor-ai/history', {
+            method: 'POST',
+            body: JSON.stringify({
+                id: 'session-1',
+                title: 'Hacked Title',
+                messages: []
+            })
+        });
+
+        const res: any = await POST(req);
+
+        expect(res.status).toBe(403);
+        expect(res.body).toEqual({ error: 'Forbidden' });
+
+        // Optimized: findFirst NOT called
+        expect(mockFindFirst).toHaveBeenCalledTimes(0);
+        // Insert called (attempted upsert)
+        expect(mockInsert).toHaveBeenCalledTimes(1);
+        expect(mockUpdate).toHaveBeenCalledTimes(0);
+    });
+});


### PR DESCRIPTION
💡 **What:** Replaced the "findFirst + update/insert" pattern in `src/app/api/mentor-ai/history/route.ts` with a single `INSERT ... ON CONFLICT DO UPDATE` (upsert) query using Drizzle ORM.
🎯 **Why:** To reduce database round-trips and improve latency for saving chat sessions. This eliminates the initial read query while maintaining strict ownership checks via the `where` clause in the upsert.
📊 **Measured Improvement:**
- **Baseline:** 2 database calls (Read + Write) for updates and creates.
- **Optimized:** 1 database call (Upsert) for updates and creates.
- **Verification:** Added `src/app/api/mentor-ai/history/route.test.ts` to verify the behavior and count DB calls, ensuring the logic (including 403 Forbidden for ownership mismatch) is preserved.

---
*PR created automatically by Jules for task [1982756572673051516](https://jules.google.com/task/1982756572673051516) started by @hadianr*