### PR TITLE
Fix hardcoded intention ID in MissionsWidget

### DIFF
--- a/src/components/MissionsWidget.tsx
+++ b/src/components/MissionsWidget.tsx
@@ -632,14 +632,11 @@ export default function MissionsWidget() {
                                 );
                             }
                         } else if (selectedMission.id === 'muhasabah' && userToken) {
-                            // For now we pass a dummy ID or handle it inside. 
-                            // Ideally we fetch the daily intention ID here.
-                            // Assuming the API might handle 'latest' or we need to fetch it.
-                            // TODO: Fetch real intention ID
                             customContent = (
                                 <ReflectionInputForm
                                     userToken={userToken}
-                                    intentionId="latest" // Placeholder, backend needs to support or we fetch
+                                    intentionId={todayIntention?.id}
+                                    intentionText={todayIntention?.text}
                                     onComplete={() => handleCompleteMission(selectedMission.xpReward)}
                                 />
                             );


### PR DESCRIPTION
Replaced hardcoded "latest" intention ID with `todayIntention?.id` in `MissionsWidget.tsx`.
Passed `intentionText` prop to `ReflectionInputForm` to display the intention text during reflection.
Removed TODO comments related to fetching real intention ID.

---
*PR created automatically by Jules for task [10037691306642507368](https://jules.google.com/task/10037691306642507368) started by @hadianr*