### PR TITLE
🧹 [code health] handle silenced errors in LocaleContext.tsx

### DIFF
--- a/src/context/LocaleContext.tsx
+++ b/src/context/LocaleContext.tsx
@@ -19,6 +19,7 @@
  */
 
 import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import * as Sentry from "@sentry/nextjs";
 import { SETTINGS_TRANSLATIONS } from "@/data/settings-translations";
 import { RAMADHAN_TRANSLATIONS } from "@/data/ramadhan-translations";
 import { getStorageService } from "@/core/infrastructure/storage";
@@ -61,6 +62,7 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
       const savedLocale = (storage.getOptional(STORAGE_KEYS.SETTINGS_LOCALE) as string) || DEFAULT_LOCALE;
       setLocaleState(savedLocale);
     } catch (error) {
+      Sentry.captureException(error);
       setLocaleState(DEFAULT_LOCALE);
     } finally {
       setIsLoading(false);
@@ -94,6 +96,7 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
         new CustomEvent("locale-changed", { detail: { locale: newLocale } })
       );
     } catch (error) {
+      Sentry.captureException(error);
     }
   };
 


### PR DESCRIPTION
This PR addresses a code health issue in `src/context/LocaleContext.tsx` where errors during locale initialization and update were being silenced.

Changes:
- Imported `Sentry` from `@sentry/nextjs`.
- Added `Sentry.captureException(error)` to the `catch` block in the initialization `useEffect`.
- Added `Sentry.captureException(error)` to the `catch` block in the `setLocale` function.

These changes ensure that any runtime errors related to storage or cookie management are reported to Sentry, improving observability and maintainability without changing the application's behavior.

Verification:
- Manual code inspection confirmed the changes follow the codebase's existing patterns for error reporting (e.g., in `useRamadhanCalendar.ts`).
- Code review confirmed the solution is correct and safe.
- Attempted to run tests and lint, but were blocked by pre-existing environment dependency issues.


---
*PR created automatically by Jules for task [4070559609176297862](https://jules.google.com/task/4070559609176297862) started by @hadianr*