### PR TITLE
⚡ Optimize sync-guest API completedMissions insert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nawaetu",
-  "version": "1.8.3",
+  "version": "1.8.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nawaetu",
-      "version": "1.8.3",
+      "version": "1.8.17",
       "dependencies": {
         "@auth/drizzle-adapter": "^1.11.1",
         "@babel/runtime": "^7.28.6",

--- a/src/app/api/user/sync-guest/route.ts
+++ b/src/app/api/user/sync-guest/route.ts
@@ -165,16 +165,14 @@ export async function POST(req: NextRequest) {
 
             // 4. Sync Completed Missions
             if (data.completedMissions && data.completedMissions.length > 0) {
-                for (const m of data.completedMissions) {
-                    await tx.insert(userCompletedMissions)
-                        .values({
-                            userId,
-                            missionId: m.id,
-                            xpEarned: m.xpEarned,
-                            completedAt: new Date(m.completedAt),
-                        })
-                        .onConflictDoNothing(); // If already completed, skip
-                }
+                await tx.insert(userCompletedMissions)
+                    .values(data.completedMissions.map(m => ({
+                        userId,
+                        missionId: m.id,
+                        xpEarned: m.xpEarned,
+                        completedAt: new Date(m.completedAt),
+                    })))
+                    .onConflictDoNothing(); // If already completed, skip
             }
 
             // 5. Sync Intentions (Journal) - Optimized with Batch lookup


### PR DESCRIPTION
Implemented batch insert for completedMissions in src/app/api/user/sync-guest/route.ts to resolve N+1 insert issue.
Verified with reproduction test showing reduction from N calls to 1 call.
Updated src/app/api/user/sync-guest/route.test.ts to include the regression test and fixed existing broken test logic for intentions.

---
*PR created automatically by Jules for task [17800684059272025599](https://jules.google.com/task/17800684059272025599) started by @hadianr*