### PR TITLE
Implement proper Isha end time logic

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,14 @@
+npm warn exec The following package was not found and will be installed: next@16.1.6
+⚠ Installing TypeScript as it was not found while loading "next.config.ts".
+
+Installing devDependencies (npm):
+- typescript
+
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated whatwg-encoding@3.1.1: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+npm warn deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
+npm warn deprecated @esbuild-kit/esm-loader@2.6.5: Merged into tsx: https://tsx.is
+npm warn deprecated @esbuild-kit/core-utils@3.3.2: Merged into tsx: https://tsx.is
+npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead

--- a/src/components/MissionsWidget.tsx
+++ b/src/components/MissionsWidget.tsx
@@ -468,7 +468,7 @@ export default function MissionsWidget() {
                             else if (prayerKey === 'Dhuhr') endTimeStr = prayerData.prayerTimes['Asr'];
                             else if (prayerKey === 'Asr') endTimeStr = prayerData.prayerTimes['Maghrib'];
                             else if (prayerKey === 'Maghrib') endTimeStr = prayerData.prayerTimes['Isha'];
-                            // Isha end is tricky, let's ignore or use fixed offset.
+                            else if (prayerKey === 'Isha') endTimeStr = prayerData.prayerTimes['Midnight'];
 
                             if (pTime && endTimeStr) {
                                 const now = new Date();
@@ -477,6 +477,11 @@ export default function MissionsWidget() {
 
                                 const startDate = new Date(); startDate.setHours(sH, sM, 0, 0);
                                 const endDate = new Date(); endDate.setHours(eH, eM, 0, 0);
+
+                                // Handle day rollover (e.g. Isha 19:00 -> Midnight 00:15)
+                                if (endDate < startDate) {
+                                    endDate.setDate(endDate.getDate() + 1);
+                                }
 
                                 const diffMs = now.getTime() - startDate.getTime();
                                 const remainingMs = endDate.getTime() - now.getTime();

--- a/src/hooks/usePrayerTimes.ts
+++ b/src/hooks/usePrayerTimes.ts
@@ -85,6 +85,7 @@ export function usePrayerTimes(): UsePrayerTimesResult {
             Asr: timings.Asr,
             Maghrib: timings.Maghrib,
             Isha: timings.Isha,
+            Midnight: timings.Midnight,
         };
 
         const now = new Date();


### PR DESCRIPTION
Implemented proper end time calculation for Isha prayer in `MissionsWidget`.
Previously, Isha end time was ignored or assumed to use a fixed offset.
Now, it uses the Islamic Midnight (calculated as halfway between Maghrib and Fajr, or returned by the prayer times API) as the end time.
The logic handles cases where Midnight falls on the next day (e.g., Isha 19:15, Midnight 00:15).

Testing:
- Verified the date rollover logic with a standalone script (`verify_isha_logic.ts`).
- Confirmed `Midnight` is available in `usePrayerTimes` hook.

---
*PR created automatically by Jules for task [13542926166034396920](https://jules.google.com/task/13542926166034396920) started by @hadianr*