### PR TITLE
🔒 fix: remove sensitive user_token from query params on /api/intentions/today

### DIFF
--- a/src/app/api/intentions/today/route.ts
+++ b/src/app/api/intentions/today/route.ts
@@ -31,8 +31,8 @@ import { authOptions } from "@/lib/auth";
  */
 export async function GET(req: NextRequest) {
     const startTime = Date.now();
-    const { searchParams } = req.nextUrl;
-    const providedToken = searchParams.get("user_token");
+    const authHeader = req.headers.get("authorization");
+    const providedToken = authHeader?.startsWith("Bearer ") ? authHeader.substring(7) : null;
 
     try {
         const session = await getServerSession(authOptions);

--- a/src/components/MissionsWidget.tsx
+++ b/src/components/MissionsWidget.tsx
@@ -94,7 +94,9 @@ export default function MissionsWidget() {
 
         const fetchIntention = async () => {
             try {
-                const res = await fetch(`/api/intentions/today?user_token=${userToken}`);
+                const res = await fetch(`/api/intentions/today`, {
+                    headers: { 'Authorization': `Bearer ${userToken}` }
+                });
                 const data = await res.json();
                 if (data.success && data.data.has_intention) {
                     setTodayIntention({

--- a/src/components/intentions/IntentionJournalWidget.tsx
+++ b/src/components/intentions/IntentionJournalWidget.tsx
@@ -101,9 +101,12 @@ export default function IntentionJournalWidget({ className = "" }: IntentionJour
         const checkTodayStatus = async () => {
             try {
                 // Background fetch
-                const response = await fetch(`/api/intentions/today?user_token=${userToken}`, {
+                const response = await fetch(`/api/intentions/today`, {
                     // Cache busting or ensure next.js doesn't hard cache this for real-time widgets
-                    headers: { 'Cache-Control': 'no-cache' }
+                    headers: {
+                        'Cache-Control': 'no-cache',
+                        'Authorization': `Bearer ${userToken}`
+                    }
                 });
 
                 if (response.ok) {


### PR DESCRIPTION
🎯 **What:** The user token is now passed via the `Authorization` header rather than the `user_token` URL query parameter for the `/api/intentions/today` endpoint.
⚠️ **Risk:** Query parameters can be logged by reverse proxies, API gateways, load balancers, and potentially exposed in browser histories or monitoring tools. If a malicious actor gains access to these logs, they could extract sensitive tokens and impersonate users.
🛡️ **Solution:** Modified the API route `src/app/api/intentions/today/route.ts` to expect a Bearer token in the `Authorization` header. Updated the frontend components (`IntentionJournalWidget.tsx` and `MissionsWidget.tsx`) to supply the token securely via the headers in their respective `fetch` calls, completely removing the query parameter.

---
*PR created automatically by Jules for task [181861110905813832](https://jules.google.com/task/181861110905813832) started by @hadianr*