### PR TITLE
🧹 Remove leftover console.log in payment webhook

### DIFF
--- a/src/app/api/payment/webhook/route.ts
+++ b/src/app/api/payment/webhook/route.ts
@@ -95,8 +95,6 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ error: "Invalid Payload: Missing Transaction ID" }, { status: 400 });
         }
 
-        console.log(`[Mayar Webhook] Processing: MayarID=${mayarId}, ProductID=${productId}, Status=${status}`);
-
         // 5. Transaction Lookup Strategy
         const conditions = [eq(transactions.mayarId, mayarId)];
         if (linkId) conditions.push(eq(transactions.paymentLinkId, linkId));


### PR DESCRIPTION
🎯 **What:** Removed a leftover `console.log` statement tracking processing information in the Mayar Webhook route.
💡 **Why:** `console.log` statements are useful for debugging during development, but leaving them in production code clutters logs and can make it difficult to identify actual warnings or errors. This improves code health and cleanliness.
✅ **Verification:** Ran `pre_commit_instructions` tests and confirmed no impact on functional logic. It successfully removed the log on line 98 without breaking the flow.
✨ **Result:** A cleaner webhook file without debug trace logs in production logs.

---
*PR created automatically by Jules for task [1803961022660868774](https://jules.google.com/task/1803961022660868774) started by @hadianr*