### PR TITLE
🧹 [Code Health] Remove leftover console.log in Mayar Webhook

### DIFF
--- a/src/app/api/payment/webhook/route.ts
+++ b/src/app/api/payment/webhook/route.ts
@@ -133,7 +133,6 @@ export async function POST(req: NextRequest) {
                         .where(eq(transactions.id, potentialTx.id));
 
                     transaction = potentialTx;
-                    console.log(`[Mayar Webhook] Fallback Sucess. Linked to Transaction ID: ${transaction.id}`);
                 }
             }
         }


### PR DESCRIPTION
🎯 **What:** Removed a leftover `console.log` statement in the Mayar webhook route `src/app/api/payment/webhook/route.ts` that logged a successful fallback operation.

💡 **Why:** `console.log` statements are useful for local debugging but should be removed from production code to keep the terminal output clean and reduce unnecessary noise in server logs.

✅ **Verification:**
- Verified the removal with `grep "Fallback Sucess" src/app/api/payment/webhook/route.ts`.
- Confirmed the surrounding code logic was not modified or broken.
- Tested successfully by code review since the change is extremely trivial and risk-free.

✨ **Result:** A cleaner webhook route file and less noise in production logs.

---
*PR created automatically by Jules for task [15417358684955623577](https://jules.google.com/task/15417358684955623577) started by @hadianr*