### PR TITLE
chore(deps): ignore unsupported TypeScript 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: /
     patterns:
       - '*'
+    ignore:
+      - dependency-name: typescript
+        versions: [">= 7.0.0"]
     open-pull-requests-limit: 1
     multi-ecosystem-group: routine-dependencies
 


### PR DESCRIPTION
## Summary

Ignore TypeScript major version 7 in Dependabot because the current Next.js ESLint toolchain rejects TypeScript 7.0.

Closes #

## Change type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / performance
- [x] Documentation / maintenance

## Validation
- [x] YAML syntax validated
- [x] `git diff --check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm run build`
- [ ] Manual testing completed (not applicable)

## Impact & safety
- Breaking change: No
- Database migration: No
- Environment variable/config change: No
- FCM/auth/payment/sync impact: No
- Deployment notes or rollback steps: Revert the single Dependabot ignore entry.

## Review notes

This narrowly ignores `typescript >= 7.0.0`; all other Dependabot npm updates remain enabled.