### PR TITLE
test: use local date in mission fixture

### DIFF
--- a/src/hooks/__tests__/useWidgetMissions.test.ts
+++ b/src/hooks/__tests__/useWidgetMissions.test.ts
@@ -3,6 +3,7 @@
  */
 import { renderHook } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
+import { DateUtils } from "@/lib/utils/date";
 import { useWidgetMissions } from "../useWidgetMissions";
 
 vi.mock("next-auth/react", () => ({
@@ -44,7 +45,7 @@ describe("useWidgetMissions Friday handling", () => {
     });
 
     it("syncs prayer completion correctly between prayer check-in and mission list", () => {
-        const todayStr = new Date().toISOString().split("T")[0];
+        const todayStr = DateUtils.today();
         const completedMissions = [
             { id: "fajr_prayer", completedAt: todayStr }
         ];


### PR DESCRIPTION
## Summary

Use the shared local-date helper in the mission completion test so the fixture matches production date semantics across timezones.

## Change type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / performance
- [ ] Documentation / maintenance

## Validation
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (259/259 tests, 80.33% lines)
- [ ] `npm run build`
- [ ] Manual testing completed (not applicable)

## Impact & safety
- Breaking change: No
- Database migration: No
- Environment variable/config change: No
- FCM/auth/payment/sync impact: No
- Deployment notes or rollback steps: None; test-only change.

## Review notes

Fixes a timezone-dependent test failure without changing production behavior.