### PR TITLE
fix(security): address CodeQL alerts

### DIFF
--- a/src/app/notification-debug/page.tsx
+++ b/src/app/notification-debug/page.tsx
@@ -344,51 +344,6 @@ export default function NotificationDebugPage() {
                 </div>
 
                 <div className="border p-4 rounded-lg border-gray-700">
-                    <h2 className="font-semibold mb-2">2. Update Location Data</h2>
-                    <p className="text-sm text-gray-400 mb-2">
-                        Forcing GPS detection to fix &quot;userLocation: null&quot;.
-                    </p>
-                    <button
-                        onClick={async () => {
-                            setLoading(true);
-                            if (!navigator.geolocation) {
-                                alert("Geolocation not supported");
-                                setLoading(false);
-                                return;
-                            }
-                            navigator.geolocation.getCurrentPosition(
-                                async (pos) => {
-                                    const loc = { lat: pos.coords.latitude, lng: pos.coords.longitude };
-                                    // If token exists, sync to DB
-                                    if (token) {
-                                        await fetch("/api/notifications/subscribe", {
-                                            method: "POST",
-                                            headers: { "Content-Type": "application/json" },
-                                            body: JSON.stringify({
-                                                token: token,
-                                                deviceType: "web",
-                                                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                                                userLocation: loc
-                                            }),
-                                        });
-                                    }
-                                    alert("Location updated successfully!");
-                                    setLoading(false);
-                                },
-                                (err) => {
-                                    alert("Error: " + err.message);
-                                    setLoading(false);
-                                }
-                            );
-                        }}
-                        className="bg-purple-600 px-4 py-2 rounded text-sm text-white disabled:opacity-50"
-                        disabled={loading}
-                    >
-                        Detect & Sync My Location
-                    </button>
-                </div>
-
-                <div className="border p-4 rounded-lg border-gray-700">
                     <h2 className="font-semibold mb-2">3. Force Test Notification</h2>
                     <p className="text-sm text-gray-400 mb-2">
                         Sends an immediate high-priority notification to a specific token.

--- a/src/components/quran/VerseItem.tsx
+++ b/src/components/quran/VerseItem.tsx
@@ -73,7 +73,7 @@ function isVerseWord(word: unknown): word is VerseWord {
 // In quran-utils, cleanTajweedText wasn't exported.
 // Note: We need to export cleanTajweedText from sanitize or rename if needed.
 // Wait, cleanTajweedText is imported from sanitize in VerseList.
-import { cleanTajweedText as sanitizeTajweedText, sanitizePlainText } from "@/lib/sanitize";
+import { cleanTajweedText as sanitizeTajweedText } from "@/lib/sanitize";
 import { useState } from "react";
 
 export default function VerseItem({
@@ -262,8 +262,8 @@ export default function VerseItem({
                                             </span>
                                         )}
                                         {word.translation?.text && (
-                                            <span className="text-[9px] md:text-[10px] text-slate-400 text-center leading-tight max-w-[90px] group-hover:text-slate-200 line-clamp-2" title={sanitizePlainText(word.translation.text)}>
-                                                {sanitizePlainText(word.translation.text)}
+                                            <span className="text-[9px] md:text-[10px] text-slate-400 text-center leading-tight max-w-[90px] group-hover:text-slate-200 line-clamp-2" title={word.translation.text}>
+                                                {word.translation.text}
                                             </span>
                                         )}
                                     </div>


### PR DESCRIPTION
## Summary

Address the three active CodeQL alerts:
- Render Quran translations as escaped JSX text instead of applying a custom sanitizer to text-only output.
- Remove the development-only debug-page flow that directly sends precise GPS coordinates as clear-text location data.

## Change type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / performance
- [ ] Documentation / maintenance

## Validation
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (259/259 tests, 80.4% lines)
- [ ] `npm run build` (blocked locally by unavailable Google Fonts/Sentry hosts and disk space)
- [ ] Manual testing completed (development-only page change)

## Impact & safety
- Breaking change: No
- Database migration: No
- Environment variable/config change: No
- FCM/auth/payment/sync impact: Removes only the development-only direct GPS sync button.
- Deployment notes or rollback steps: Revert this PR if the debug-only location button is required; normal location handling remains unchanged.

## Review notes

React escapes translation strings rendered as JSX text and attributes. Tajweed HTML rendering remains protected by the existing DOMPurify allowlist.