### PR TITLE
ci: analyze CodeQL on main pushes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,8 @@
 name: CodeQL
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   schedule:


### PR DESCRIPTION
## Summary

Run CodeQL on every push to `main` so the default branch receives current Code Scanning results and stale alerts can be reconciled.

## Change type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / performance
- [x] Documentation / maintenance

## Validation
- [x] `git diff --check`
- [x] CodeQL workflow syntax reviewed
- [ ] CI checks

## Impact & safety
- Breaking change: No
- Database migration: No
- Environment variable/config change: No
- FCM/auth/payment/sync impact: No
- Deployment notes or rollback steps: None; this only adds a `push` trigger for `main`.

## Review notes

GitHub CodeQL reported that the workflow had no `on.push` hook, so successful analyses did not refresh default-branch alerts.